### PR TITLE
Make distinct client and server sockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/ArtskydJ/mock-socket.io"
   },
   "devDependencies": {
-    "tap": "^1.0.10"
+    "tap": "^2.1.1"
   },
   "scripts": {
     "test": "tap test.js"

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-﻿var test = require('tap').test
+var test = require('tap').test
 var mock = require('./')
 
 test('seems to work and stuff', {timeout:5000}, function (t) {
@@ -19,6 +19,10 @@ test('seems to work and stuff', {timeout:5000}, function (t) {
 		socket.on('the lazy', function () {
 			var argArray = [].slice.call(arguments)
 			t.deepEqual(argArray, ['do', 'gs', 'dogs'], 'the lazy dogs')
+		})
+		
+		socket.on('jumps', function(){
+		  t.bailout('jumps called on server socket')
 		})
 	})
 


### PR DESCRIPTION
Previously, the client socket and server socket were actually the
same socket instance, and they just emitted to themselves. This
works in many cases, but fails if the client and server both need
to process events with the same name. In that case, if the client
emitted the event, both the client and server would process the
event, while the intended behavior is that only the server should
process the event.

This adds a bit of complexity, but essentially creates two sockets,
where events emitted by one socket get processed by the other.
